### PR TITLE
Rollback the builds

### DIFF
--- a/LATEST.json
+++ b/LATEST.json
@@ -1,6 +1,6 @@
 {
   "arch": "arm",
-  "date": "20200124",
+  "date": "20200117",
   "assets": [
     { "api": "4.4", "variants": ["pico", "nano"]},
     { "api": "5.0", "variants": ["pico", "nano"]},


### PR DESCRIPTION
Builds for 9.0 are broken right now, need to rollback the date + include the 10.0 builds from 24th.